### PR TITLE
fix: not asking password during install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -151,7 +151,7 @@ install_grub() {
 
 install_i3() {
   echo "Installing i3 and dependencies"
-  sudo -u $USERNAME sh -c "`curl -fsSL https://raw.githubusercontent.com/Julianobsg/arch-config/master/i3_install.sh`"
+  echo $PASSWORD | sudo -u $USERNAME sh -c "`curl -fsSL https://raw.githubusercontent.com/Julianobsg/arch-config/master/i3_install.sh`"
 }
 
 finish_installation() {


### PR DESCRIPTION
After some configuration, it is unnecessary to make user retype password when install as user.